### PR TITLE
Config octokit/webhooks version as cargo metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +342,7 @@ name = "github-webhook"
 version = "0.2.2+v6.11.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "github-webhook-dts-downloader",
  "serde",
  "serde_json",
@@ -1108,6 +1141,9 @@ name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -1466,6 +1502,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/dts-downloader/src/lib.rs
+++ b/dts-downloader/src/lib.rs
@@ -19,15 +19,7 @@ pub struct Version(pub String);
 
 impl Default for Version {
     fn default() -> Self {
-        let pkg_version = env::var("CARGO_PKG_VERSION").unwrap();
-        let pkg_version = semver::Version::parse(&pkg_version).unwrap();
-        let branch_name = if !pkg_version.build.is_empty() {
-            pkg_version.build.as_str()
-        } else {
-            "master"
-        }
-        .to_string();
-        Self(branch_name)
+        Self("master".to_string())
     }
 }
 

--- a/github-webhook/Cargo.toml
+++ b/github-webhook/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 
 [package.metadata.octokit-webhooks]
 repository = "octokit/webhooks"
-version = "v6.11.0"
+version = "v6.10.0"
 
 [build-dependencies]
 github-webhook-dts-downloader.workspace = true

--- a/github-webhook/Cargo.toml
+++ b/github-webhook/Cargo.toml
@@ -13,6 +13,10 @@ readme = "../README.md"
 license = "MIT"
 # TODO: how to notice https://github.com/octokit/webhooks/blob/v6.8.0/LICENSE (MIT)
 
+[package.metadata.octokit-webhooks]
+repository = "octokit/webhooks"
+version = "v6.11.0"
+
 [build-dependencies]
 github-webhook-dts-downloader.workspace = true
 anyhow = "1.0.71"

--- a/github-webhook/Cargo.toml
+++ b/github-webhook/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT"
 [build-dependencies]
 github-webhook-dts-downloader.workspace = true
 anyhow = "1.0.71"
+cargo_metadata = "0.15.4"
 
 [dependencies]
 serde = "1.0.163"

--- a/github-webhook/build.rs
+++ b/github-webhook/build.rs
@@ -24,7 +24,22 @@ fn main() -> Result<()> {
 
     assert_eq!(pkg_name, pkg.name);
 
-    run_transform(Default::default())?;
+    let octokit_webhooks = pkg
+        .metadata
+        .get("octokit-webhooks")
+        .expect("Could not get octokit-webhooks metadata");
+
+    let octokit_ver = octokit_webhooks
+        .get("version")
+        .expect("Could not get octokit/webhooks version")
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    run_transform(github_webhook_dts_downloader::Opt {
+        version: github_webhook_dts_downloader::Version(octokit_ver),
+        ..Default::default()
+    })?;
 
     Ok(())
 }

--- a/github-webhook/build.rs
+++ b/github-webhook/build.rs
@@ -1,8 +1,29 @@
 use anyhow::Result;
+use cargo_metadata::{CargoOpt, MetadataCommand};
+use std::env;
 
 use github_webhook_dts_downloader::run_transform;
 
 fn main() -> Result<()> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR").to_string();
+    let metadata = MetadataCommand::new()
+        .manifest_path(manifest_dir + "/Cargo.toml")
+        .features(CargoOpt::AllFeatures)
+        .exec()
+        .unwrap();
+
+    // workspace manifest
+    assert_ne!(metadata.workspace_members.len(), 0);
+
+    let pkg_name = env!("CARGO_PKG_NAME");
+    let pkg = &metadata
+        .packages
+        .iter()
+        .find(|p| p.name == pkg_name)
+        .unwrap();
+
+    assert_eq!(pkg_name, pkg.name);
+
     run_transform(Default::default())?;
 
     Ok(())

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,8 @@
         "^github-webhook/Cargo.toml$"
       ],
       "matchStrings": [
-        "name = \"github-webhook\"\\nversion = \".*\\+(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
+        "name = \"github-webhook\"\\nversion = \".*\\+(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"",
+        "\\[package.metadata.octokit-webhooks\\]\nrepository\\s=\\s\"(?<depName>.*?)\"\nversion\\s=\\s\"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
       ],
       "depNameTemplate": "octokit/webhooks",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
- Resolve #63 
- `github-webhook` crate での `octokit/webhooks` のバージョン指定を `package.metadta` 経由でやる
- そのバージョンを Renovate する