### PR TITLE
github-webhook: Drop build metadata octokit/webhooks version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook"
-version = "0.2.2+v6.11.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook-dts-downloader"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "github-webhook-type-generator",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook-type-generator"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 repository = "https://github.com/sksat/github-webhook-rs"
 authors = ["sksat <sksat@sksat.net>", "s-ylide"]
 

--- a/github-webhook/Cargo.toml
+++ b/github-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-webhook"
-version = "0.2.2"
+version.workspace = true
 edition = "2021"
 
 build = "build.rs"

--- a/github-webhook/Cargo.toml
+++ b/github-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-webhook"
-version = "0.2.2+v6.11.0"
+version = "0.2.2"
 edition = "2021"
 
 build = "build.rs"


### PR DESCRIPTION
- #62 
- Resolve #63 