### PR TITLE
github-webhook: prevent generate lockfile in build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook-dts-downloader"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "github-webhook-type-generator",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook-type-generator"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 repository = "https://github.com/sksat/github-webhook-rs"
 authors = ["sksat <sksat@sksat.net>", "s-ylide"]
 

--- a/github-webhook/build.rs
+++ b/github-webhook/build.rs
@@ -9,6 +9,7 @@ fn main() -> Result<()> {
     let metadata = MetadataCommand::new()
         .manifest_path(manifest_dir + "/Cargo.toml")
         .features(CargoOpt::AllFeatures)
+        .no_deps() // prevent generate lockfile
         .exec()
         .unwrap();
 


### PR DESCRIPTION
- Fixes: #73 
- `cargo package` できるようになったので，たぶん OK