### PR TITLE
Revert "Update Rust crate cargo_metadata to 0.15.5"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.5"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f99443702b755bf0c04082e281b05d2475351dcb954b9fb8f741b66bfdb55d3"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",

--- a/github-webhook/Cargo.toml
+++ b/github-webhook/Cargo.toml
@@ -20,7 +20,7 @@ version = "v7.0.2"
 [build-dependencies]
 github-webhook-dts-downloader.workspace = true
 anyhow = "1.0.71"
-cargo_metadata = "0.15.5"
+cargo_metadata = "0.15.4"
 
 [dependencies]
 serde = { version = "1.0.163", features = ["derive"] }


### PR DESCRIPTION
Reverts sksat/github-webhook-rs#87

- #94 