### PR TITLE
Search `schema.d.ts` with environment variable `GITHUB_WEBHOOK_SCHEMA_DTS`

### DIFF
--- a/github-webhook/build.rs
+++ b/github-webhook/build.rs
@@ -12,6 +12,8 @@ use github_webhook_dts_downloader::download_dts;
 use github_webhook_type_generator::dts2rs;
 
 fn main() -> Result<()> {
+    println!("cargo:rerun-if-env-changed=GITHUB_WEBHOOK_SCHEMA_DTS");
+
     let manifest_dir = env!("CARGO_MANIFEST_DIR").to_string();
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
@@ -46,7 +48,10 @@ fn main() -> Result<()> {
         .unwrap()
         .to_string();
 
-    let dts_file = out_dir.join("schema.d.ts");
+    let dts_file = env::var("GITHUB_WEBHOOK_SCHEMA_DTS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| out_dir.join("schema.d.ts"));
 
     if !dts_file.try_exists()? {
         download_dts(github_webhook_dts_downloader::Opt {

--- a/github-webhook/build.rs
+++ b/github-webhook/build.rs
@@ -48,10 +48,12 @@ fn main() -> Result<()> {
 
     let dts_file = out_dir.join("schema.d.ts");
 
-    download_dts(github_webhook_dts_downloader::Opt {
-        version: github_webhook_dts_downloader::Version(octokit_ver),
-        out_path_ts: github_webhook_dts_downloader::OutPathTs(dts_file.clone()),
-    })?;
+    if !dts_file.try_exists()? {
+        download_dts(github_webhook_dts_downloader::Opt {
+            version: github_webhook_dts_downloader::Version(octokit_ver),
+            out_path_ts: github_webhook_dts_downloader::OutPathTs(dts_file.clone()),
+        })?;
+    }
 
     let rs = dts2rs(&dts_file);
     let rs_file = out_dir.join("types.rs");


### PR DESCRIPTION
Builds of this crate fails in environments that do not allow unexpected Internet access during the build, such as Nix. This is because `dts_downloader` performs internet access. This PR addresses this issue by providing a way to load local `schema.d.ts`.

Below is a description of how this is done.

1. Determine the path of `schema.d.ts` to be loaded from the environment variable `GITHUB_WEBHOOK_SCHEMA_DTS`.
    - If no environment variable is found, `$OUT_DIR/schema.d.ts` is chosen as the default value.
2. If there is no such file or directory in the specified path, download `schema.d.ts` from the Internet.
    - Downloading is the same as the previous behavior.
3. Generate types from `schema.d.ts`. This generating process is also the same as the previous behavior.