### PR TITLE
d.ts downloader should download only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "github-webhook-dts-downloader",
+ "github-webhook-type-generator",
  "reqwest",
  "serde",
  "serde_json",
@@ -361,7 +362,6 @@ name = "github-webhook-dts-downloader"
 version = "0.5.2"
 dependencies = [
  "anyhow",
- "github-webhook-type-generator",
  "reqwest",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "github-webhook"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook-dts-downloader"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "github-webhook-type-generator"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "once_cell",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 repository = "https://github.com/sksat/github-webhook-rs"
 authors = ["sksat <sksat@sksat.net>", "s-ylide"]
 
@@ -16,5 +16,5 @@ authors = ["sksat <sksat@sksat.net>", "s-ylide"]
 rust-version = "1.64.0"
 
 [workspace.dependencies]
-github-webhook-dts-downloader = { path = "./dts-downloader", version = "0.5" }
-github-webhook-type-generator = { path = "./type-generator", version = "0.5" }
+github-webhook-dts-downloader = { path = "./dts-downloader", version = "0.6" }
+github-webhook-type-generator = { path = "./type-generator", version = "0.6" }

--- a/dts-downloader/Cargo.toml
+++ b/dts-downloader/Cargo.toml
@@ -10,6 +10,5 @@ authors.workspace = true
 license = "MIT"
 
 [dependencies]
-github-webhook-type-generator.workspace = true
 anyhow = "1.0.79"
 reqwest = { version = "0.11.23", features = ["blocking"] }

--- a/dts-downloader/src/lib.rs
+++ b/dts-downloader/src/lib.rs
@@ -1,18 +1,12 @@
 use std::env;
-use std::fs::File;
-use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
-use std::process::Command;
 
 use anyhow::Result;
-
-use github_webhook_type_generator::dts2rs;
 
 #[derive(Default)]
 pub struct Opt {
     pub version: Version,
     pub out_path_ts: OutPathTs,
-    pub out_path_rs: OutPathRs,
 }
 
 pub struct Version(pub String);
@@ -23,7 +17,7 @@ impl Default for Version {
     }
 }
 
-pub struct OutPathTs(PathBuf);
+pub struct OutPathTs(pub PathBuf);
 
 impl Default for OutPathTs {
     fn default() -> Self {
@@ -33,21 +27,10 @@ impl Default for OutPathTs {
     }
 }
 
-pub struct OutPathRs(PathBuf);
-
-impl Default for OutPathRs {
-    fn default() -> Self {
-        let mut path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        path.push("types.rs");
-        Self(path)
-    }
-}
-
-pub fn run_transform(
+pub fn download_dts(
     Opt {
         version: Version(branch),
         out_path_ts: OutPathTs(dts_file),
-        out_path_rs: OutPathRs(rs_file),
     }: Opt,
 ) -> Result<()> {
     // setup .d.ts file
@@ -57,19 +40,6 @@ pub fn run_transform(
 
     let body = reqwest::blocking::get(url)?.text()?;
     std::fs::write(&dts_file, body)?;
-
-    let rs = dts2rs(&dts_file);
-
-    let mut writer = BufWriter::new(File::create(&rs_file)?);
-    write!(writer, "{rs}")?;
-    writer.into_inner()?;
-
-    let output = Command::new("rustfmt").arg(rs_file).output()?;
-    let status = output.status;
-    if !status.success() {
-        io::stderr().write_all(&output.stderr).unwrap();
-        panic!("failed to execute rustfmt: {status}")
-    }
 
     Ok(())
 }

--- a/github-webhook/Cargo.toml
+++ b/github-webhook/Cargo.toml
@@ -20,6 +20,7 @@ version = "v7.3.1"
 
 [build-dependencies]
 github-webhook-dts-downloader.workspace = true
+github-webhook-type-generator.workspace = true
 anyhow = "1.0.79"
 cargo_metadata = "0.18.1"
 


### PR DESCRIPTION
- currently, `dts-downloader` perform below things
  1. get version & file paths from `run_transform()` args
  2. download `schema.d.ts` file into `OUT_PATH`
  3. execute `type_generator::dts2rs()` & write generated `types.rs` into `OUT_PATH`
  4. format `types.rs`
- `dts-downloader` crate should only download `schema.d.ts` file
- move `type_generator::dts2rs()` & format logic into `github-webhook-rs` build script
- ref: https://github.com/sksat/github-webhook-rs/pull/187#issuecomment-1890698036
- this will be breaking change (0.6)