### PR TITLE
`&str`ではなく`String`を使うように

### DIFF
--- a/type-generator/src/lib.rs
+++ b/type-generator/src/lib.rs
@@ -61,9 +61,9 @@ pub fn dts2rs(dts_file: &PathBuf) -> proc_macro2::TokenStream {
                 if ident == "WebhookEvents" {
                     st.segments.push(RustSegment::Alias(RustAlias {
                         name: "WebhookEvents".to_owned(),
-                        is_borrowed: true,
+                        is_borrowed: false,
                         comment,
-                        ty: RustType::Array(Box::new(RustType::String { is_borrowed: true })),
+                        ty: RustType::Array(Box::new(RustType::String { is_borrowed: false })),
                     }));
                     continue; //return Err(anyhow!("lazy skip"));
                 }

--- a/type-generator/src/transformer/borrow.rs
+++ b/type-generator/src/transformer/borrow.rs
@@ -35,9 +35,9 @@ pub fn adapt_borrow(segments: &mut [RustSegment], type_deps: &CoDirectedAcyclicG
         }
         fn borrow_type(ty: &mut RustType, did_borrow: &mut bool, decorated: &HashSet<String>) {
             match ty {
-                RustType::String { is_borrowed } => {
-                    *is_borrowed = true;
-                    *did_borrow = true;
+                RustType::String { .. } => {
+                    // *is_borrowed = true;
+                    // *did_borrow = true;
                 }
                 RustType::Number => (),
                 RustType::Boolean => (),


### PR DESCRIPTION
JSONの文字列リテラル内に`\n`などのエスケープが入っている場合、単純な部分文字列ではデシリアライズできないため`&str`で受け取ることに失敗します。 [サンプルコード](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=675543b83ca36a4207096f73c2126dd9)

この問題を解決するため、`&str`でRustの型に変換しているところを全て`String`に変換しました。

ref: [[Solved] Serde deserialize str containig special chars - help - The Rust Programming Language Forum](https://users.rust-lang.org/t/solved-serde-deserialize-str-containig-special-chars/27218)