### PR TITLE
Replace `usize` with `u64`

### DIFF
--- a/type-generator/src/to_tokens.rs
+++ b/type-generator/src/to_tokens.rs
@@ -117,7 +117,7 @@ impl ToTokens for RustType {
                 }
                 "String"
             }
-            RustType::Number => "usize",
+            RustType::Number => "u64",
             RustType::Boolean => "bool",
             RustType::Custom(TypeName { name, is_borrowed }) => {
                 let name = id!(name);


### PR DESCRIPTION
Closed: #240 

Issueの通りですが、GitHub AppsのInstallation IDが大きすぎてwasm32上だとうまくデシリアライズできない問題を修正します。

~~(内部構造があまりわかっていないので、テストで落ちる気がします。)~~
ローカルでテスト回すのを忘れて変なことを書いてました。テスト通ります。